### PR TITLE
Update base image version to 0.10.0-beta6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   frigate:
-    image: "ghcr.io/weltenwort/frigate-synology-dsm7:v0.9.4-amd64"
+    image: "ghcr.io/weltenwort/frigate-synology-dsm7:v0.10.0-beta6-amd64"
     privileged: true
     hostname: "frigate"
     restart: "unless-stopped"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM blakeblackshear/frigate:0.9.4-amd64 AS build
+FROM blakeblackshear/frigate:0.10.0-beta6-amd64 AS build
 ARG DEBIAN_FRONTEND=noninteractive
 ADD deb-src.list /etc/apt/sources.list.d/
 RUN apt-get update \
@@ -13,7 +13,7 @@ RUN cd /root/libusb/libusb-1.0-1.0.23 \
   && patch debian/rules < /root/debian-rules-disable-udev.patch \
   && DEB_BUILD_OPTIONS="nocheck nodocs" dpkg-buildpackage -rfakeroot -b
 
-FROM blakeblackshear/frigate:0.9.4-amd64
+FROM blakeblackshear/frigate:0.10.0-beta6-amd64
 ARG DEBIAN_FRONTEND=noninteractive
 COPY --from=build /root/libusb/libusb-1.0-0_1.0.23-2build1_amd64.deb /root/
 RUN dpkg -i /root/libusb-1.0-0_1.0.23-2build1_amd64.deb

--- a/frigate.syno-dsm7.json
+++ b/frigate.syno-dsm7.json
@@ -42,7 +42,7 @@
    ],
    "exporting" : false,
    "id" : "73409f302aa673eaf739a4b4e02dd98f23376150cf54f289f3349c2015dce5af",
-   "image" : "ghcr.io/weltenwort/frigate-synology-dsm7:v0.9.4-amd64",
+   "image" : "ghcr.io/weltenwort/frigate-synology-dsm7:v0.10.0-beta6-amd64",
    "is_ddsm" : false,
    "is_package" : false,
    "links" : [],


### PR DESCRIPTION
## :memo: Summary

This bumps the base frigate image version to 0.10.0-beta6.