### PR TITLE
Adapt to 0.11.0 using a debian base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,9 @@
-FROM blakeblackshear/frigate:0.10.0-amd64 AS build
+ARG LIBUSB_PKG_VERSION=1.0.24
+ARG LIBUSB_PKG_BUILD=3
+
+FROM blakeblackshear/frigate:0.11.0-beta2 AS build
 ARG DEBIAN_FRONTEND=noninteractive
+ARG LIBUSB_PKG_VERSION
 ADD deb-src.list /etc/apt/sources.list.d/
 RUN apt-get update \
   && apt-get install -y \
@@ -9,11 +13,14 @@ RUN mkdir -p /root/libusb \
   && apt-get source libusb-1.0-0 \
   && apt-get build-dep -y libusb-1.0-0
 ADD debian-rules-disable-udev.patch /root/
-RUN cd /root/libusb/libusb-1.0-1.0.23 \
+RUN cd "/root/libusb/libusb-1.0-${LIBUSB_PKG_VERSION}" \
   && patch debian/rules < /root/debian-rules-disable-udev.patch \
   && DEB_BUILD_OPTIONS="nocheck nodocs" dpkg-buildpackage -rfakeroot -b
 
-FROM blakeblackshear/frigate:0.10.0-amd64
+FROM blakeblackshear/frigate:0.11.0-beta2
 ARG DEBIAN_FRONTEND=noninteractive
-COPY --from=build /root/libusb/libusb-1.0-0_1.0.23-2build1_amd64.deb /root/
-RUN dpkg -i /root/libusb-1.0-0_1.0.23-2build1_amd64.deb
+ARG LIBUSB_PKG_VERSION
+ARG LIBUSB_PKG_BUILD
+ARG TARGETARCH
+COPY --from=build "/root/libusb/libusb-1.0-0_${LIBUSB_PKG_VERSION}-${LIBUSB_PKG_BUILD}_${TARGETARCH}.deb" /root/
+RUN dpkg -i "/root/libusb-1.0-0_${LIBUSB_PKG_VERSION}-${LIBUSB_PKG_BUILD}_${TARGETARCH}.deb"

--- a/docker/deb-src.list
+++ b/docker/deb-src.list
@@ -1,1 +1,1 @@
-deb-src http://archive.ubuntu.com/ubuntu/ focal main restricted
+deb-src http://deb.debian.org/debian bullseye main


### PR DESCRIPTION
## :memo: Summary

This adapts the apt sources list to use the debian repos instead of the ubuntu ones.

closes #41 
