### PR TITLE
Update and fix build for 0.11.0 beta 2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   frigate:
-    image: "ghcr.io/weltenwort/frigate-synology-dsm7:v0.10.0-amd64"
+    image: "ghcr.io/weltenwort/frigate-synology-dsm7:v0.11.0-beta2"
     privileged: true
     hostname: "frigate"
     restart: "unless-stopped"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,9 @@
+ARG LIBUSB_PKG_VERSION=1.0.24
+ARG LIBUSB_PKG_BUILD=3
+
 FROM blakeblackshear/frigate:0.11.0-beta2 AS build
 ARG DEBIAN_FRONTEND=noninteractive
+ARG LIBUSB_PKG_VERSION
 ADD deb-src.list /etc/apt/sources.list.d/
 RUN apt-get update \
   && apt-get install -y \
@@ -9,11 +13,14 @@ RUN mkdir -p /root/libusb \
   && apt-get source libusb-1.0-0 \
   && apt-get build-dep -y libusb-1.0-0
 ADD debian-rules-disable-udev.patch /root/
-RUN cd /root/libusb/libusb-1.0-1.0.24 \
+RUN cd "/root/libusb/libusb-1.0-${LIBUSB_PKG_VERSION}" \
   && patch debian/rules < /root/debian-rules-disable-udev.patch \
   && DEB_BUILD_OPTIONS="nocheck nodocs" dpkg-buildpackage -rfakeroot -b
 
 FROM blakeblackshear/frigate:0.11.0-beta2
 ARG DEBIAN_FRONTEND=noninteractive
-COPY --from=build /root/libusb/libusb-1.0-0_1.0.24-3_amd64.deb /root/
-RUN dpkg -i /root/libusb-1.0-0_1.0.24-3_amd64.deb
+ARG LIBUSB_PKG_VERSION
+ARG LIBUSB_PKG_BUILD
+ARG TARGETARCH
+COPY --from=build "/root/libusb/libusb-1.0-0_${LIBUSB_PKG_VERSION}-${LIBUSB_PKG_BUILD}_${TARGETARCH}.deb" /root/
+RUN dpkg -i "/root/libusb-1.0-0_${LIBUSB_PKG_VERSION}-${LIBUSB_PKG_BUILD}_${TARGETARCH}.deb"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,11 +9,11 @@ RUN mkdir -p /root/libusb \
   && apt-get source libusb-1.0-0 \
   && apt-get build-dep -y libusb-1.0-0
 ADD debian-rules-disable-udev.patch /root/
-RUN cd /root/libusb/libusb-1.0-1.0.23 \
+RUN cd /root/libusb/libusb-1.0-1.0.24 \
   && patch debian/rules < /root/debian-rules-disable-udev.patch \
   && DEB_BUILD_OPTIONS="nocheck nodocs" dpkg-buildpackage -rfakeroot -b
 
 FROM blakeblackshear/frigate:0.10.0-amd64
 ARG DEBIAN_FRONTEND=noninteractive
-COPY --from=build /root/libusb/libusb-1.0-0_1.0.23-2build1_amd64.deb /root/
-RUN dpkg -i /root/libusb-1.0-0_1.0.23-2build1_amd64.deb
+COPY --from=build /root/libusb/libusb-1.0-0_1.0.24-3_amd64.deb /root/
+RUN dpkg -i /root/libusb-1.0-0_1.0.24-3_amd64.deb

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM blakeblackshear/frigate:0.10.0-amd64 AS build
+FROM blakeblackshear/frigate:0.11.0-beta2 AS build
 ARG DEBIAN_FRONTEND=noninteractive
 ADD deb-src.list /etc/apt/sources.list.d/
 RUN apt-get update \
@@ -13,7 +13,7 @@ RUN cd /root/libusb/libusb-1.0-1.0.24 \
   && patch debian/rules < /root/debian-rules-disable-udev.patch \
   && DEB_BUILD_OPTIONS="nocheck nodocs" dpkg-buildpackage -rfakeroot -b
 
-FROM blakeblackshear/frigate:0.10.0-amd64
+FROM blakeblackshear/frigate:0.11.0-beta2
 ARG DEBIAN_FRONTEND=noninteractive
 COPY --from=build /root/libusb/libusb-1.0-0_1.0.24-3_amd64.deb /root/
 RUN dpkg -i /root/libusb-1.0-0_1.0.24-3_amd64.deb

--- a/docker/deb-src.list
+++ b/docker/deb-src.list
@@ -1,1 +1,1 @@
-deb-src http://archive.ubuntu.com/ubuntu/ focal main restricted
+deb-src http://deb.debian.org/debian bullseye main

--- a/frigate.syno-dsm7.json
+++ b/frigate.syno-dsm7.json
@@ -42,7 +42,7 @@
    ],
    "exporting" : false,
    "id" : "73409f302aa673eaf739a4b4e02dd98f23376150cf54f289f3349c2015dce5af",
-   "image" : "ghcr.io/weltenwort/frigate-synology-dsm7:v0.10.0-amd64",
+   "image" : "ghcr.io/weltenwort/frigate-synology-dsm7:v0.11.0-beta2",
    "is_ddsm" : false,
    "is_package" : false,
    "links" : [],


### PR DESCRIPTION
Debian is now used for the base image, and it's now multi-arch.