### PR TITLE
Update base image version to 0.11.0-beta4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   frigate:
-    image: "ghcr.io/weltenwort/frigate-synology-dsm7:v0.11.0-beta2"
+    image: "ghcr.io/weltenwort/frigate-synology-dsm7:v0.11.0-beta4"
     privileged: true
     hostname: "frigate"
     restart: "unless-stopped"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG LIBUSB_PKG_VERSION=1.0.24
 ARG LIBUSB_PKG_BUILD=3
 
-FROM blakeblackshear/frigate:0.11.0-beta2 AS build
+FROM blakeblackshear/frigate:0.11.0-beta4 AS build
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LIBUSB_PKG_VERSION
 ADD deb-src.list /etc/apt/sources.list.d/
@@ -17,7 +17,7 @@ RUN cd "/root/libusb/libusb-1.0-${LIBUSB_PKG_VERSION}" \
   && patch debian/rules < /root/debian-rules-disable-udev.patch \
   && DEB_BUILD_OPTIONS="nocheck nodocs" dpkg-buildpackage -rfakeroot -b
 
-FROM blakeblackshear/frigate:0.11.0-beta2
+FROM blakeblackshear/frigate:0.11.0-beta4
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LIBUSB_PKG_VERSION
 ARG LIBUSB_PKG_BUILD

--- a/frigate.syno-dsm7.json
+++ b/frigate.syno-dsm7.json
@@ -42,7 +42,7 @@
    ],
    "exporting" : false,
    "id" : "73409f302aa673eaf739a4b4e02dd98f23376150cf54f289f3349c2015dce5af",
-   "image" : "ghcr.io/weltenwort/frigate-synology-dsm7:v0.11.0-beta2",
+   "image" : "ghcr.io/weltenwort/frigate-synology-dsm7:v0.11.0-beta4",
    "is_ddsm" : false,
    "is_package" : false,
    "links" : [],


### PR DESCRIPTION
Built and tested to make sure the image is okay.
Link to beta docs: https://deploy-preview-2829--frigate-docs.netlify.app/
Note that the hardware acceleration parameters have changed for beta 3 and higher.