### PR TITLE
Fix typo in docker-compose invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This provides a `Dockerfile` (with context) as well as a `docker-compose.yml` fi
 6. Start the container:
 
    ```sh
-   sudo docker-compose up --detach --force-create
+   sudo docker-compose up --detach --force-recreate
    ```
 
 ## Usage on the NAS with `docker-compose` and `git`
@@ -74,5 +74,5 @@ This provides a `Dockerfile` (with context) as well as a `docker-compose.yml` fi
 6. Start the container:
 
    ```sh
-   sudo docker-compose up --detach --force-create
+   sudo docker-compose up --detach --force-recreate
    ```


### PR DESCRIPTION
## :memo: Summary

This fixes a small typo in the README by correcting the `docker-compose` argument `--force-create` to `--force-recreate`.

closes #50