### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,5 @@ services:
       - "1935:1935" # RTMP feeds
     env_file:
       - "./secrets.env"
+    environment:
+      - LIBVA_DRIVER_NAME_JELLYFIN=i965 # if hwacl isn't working properly with the defaul iHD driver


### PR DESCRIPTION
It can solve hwacl problem is the iHD driver isn't working correcly with jellyfin-ffmpeg (issue: https://github.com/blakeblackshear/frigate/issues/3227). Seem to occur on Intel based processors, which are most seen in Synology.